### PR TITLE
docs: add global value set metadata

### DIFF
--- a/force-app/main/default/globalValueSets/SurveyRuleObjects.globalValueSet-meta.xml
+++ b/force-app/main/default/globalValueSets/SurveyRuleObjects.globalValueSet-meta.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<GlobalValueSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <customValue>
+        <fullName>Case</fullName>
+        <default>false</default>
+        <label>Case</label>
+    </customValue>
+    <customValue>
+        <fullName>Contact</fullName>
+        <default>false</default>
+        <label>Contact</label>
+    </customValue>
+    <customValue>
+        <fullName>Lead</fullName>
+        <default>false</default>
+        <label>Lead</label>
+    </customValue>
+    <description
+  >Objects which are available for choosing in survey trigger rules.</description>
+    <masterLabel>Survey Rule Objects</masterLabel>
+    <sorted>false</sorted>
+</GlobalValueSet>


### PR DESCRIPTION
Добавила global value set для определения объектов, доступных как related objects у survey.
![Comment](https://user-images.githubusercontent.com/35733535/102998961-418acd00-4539-11eb-8abd-6e59cb01cf44.png)

