### PR TITLE
fix/bugs with questions and validations

### DIFF
--- a/force-app/main/default/flows/Survey_Flow.flow-meta.xml
+++ b/force-app/main/default/flows/Survey_Flow.flow-meta.xml
@@ -131,7 +131,7 @@
         <allowFinish>true</allowFinish>
         <allowPause>true</allowPause>
         <connector>
-            <targetReference>Validations_Screen</targetReference>
+            <targetReference>Validation_Screen</targetReference>
         </connector>
         <fields>
             <name>QuestionScreenComponent</name>
@@ -271,8 +271,8 @@
         <showHeader>true</showHeader>
     </screens>
     <screens>
-        <name>Validations_Screen</name>
-        <label>Validations Screen</label>
+        <name>Validation_Screen</name>
+        <label>Validation Screen</label>
         <locationX>176</locationX>
         <locationY>518</locationY>
         <allowBack>true</allowBack>
@@ -298,10 +298,6 @@
                 </value>
             </inputParameters>
             <isRequired>true</isRequired>
-            <outputParameters>
-                <assignToReference>QuestionList</assignToReference>
-                <name>questions</name>
-            </outputParameters>
             <outputParameters>
                 <assignToReference>ValidationList</assignToReference>
                 <name>validations</name>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -64,6 +64,13 @@
         <value>Compared Value</value>
     </labels>
     <labels>
+        <fullName>complete_this_field</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>complete this field</shortDescription>
+        <value>Complete this field</value>
+    </labels>
+    <labels>
         <fullName>connect_to_another_survey</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/labels/CustomLabels.labels-meta.xml
+++ b/force-app/main/default/labels/CustomLabels.labels-meta.xml
@@ -428,6 +428,13 @@
         <value>Question Setting</value>
     </labels>
     <labels>
+        <fullName>questions_connected</fullName>
+        <language>en_US</language>
+        <protected>true</protected>
+        <shortDescription>questions connected</shortDescription>
+        <value>These questions are already connected in another validation</value>
+    </labels>
+    <labels>
         <fullName>remove_image</fullName>
         <language>en_US</language>
         <protected>true</protected>

--- a/force-app/main/default/lwc/questionForm/labels.js
+++ b/force-app/main/default/lwc/questionForm/labels.js
@@ -14,6 +14,7 @@ import option_already_exists from "@salesforce/label/c.option_already_exists";
 import error_few_options from "@salesforce/label/c.error_few_options";
 import errorTitle from "@salesforce/label/c.error";
 import success from "@salesforce/label/c.success";
+import complete_this_field from "@salesforce/label/c.complete_this_field";
 
 const label = {
   edit_question_form_title,
@@ -31,7 +32,8 @@ const label = {
   option_already_exists,
   error_few_options,
   errorTitle,
-  success
+  success,
+  complete_this_field 
 }
 
 export {

--- a/force-app/main/default/lwc/questionForm/questionForm.html
+++ b/force-app/main/default/lwc/questionForm/questionForm.html
@@ -13,7 +13,6 @@
       type="text"
       label={label.specify_question}
       onchange={handleLabel}
-      required="true"
     ></lightning-input>
 
     <div class="slds-grid slds-wrap">
@@ -61,7 +60,6 @@
             class="option-input"
             type="text"
             label={label.enter_option_value}
-            required
           ></lightning-input>
 
           <template if:true={isEditOption}>
@@ -94,18 +92,18 @@
     <div class="slds-text-align_center modal_buttons">
       <template if:true={isEditMode}>
         <lightning-button
-          variant="brand"
-          label={label.save_changes}
-          class="slds-m-left_x-small"
-          onclick={updateQuestion}
-        >
-        </lightning-button>
-
-        <lightning-button
           variant="destructive"
           label={label.cancel_edit}
           class="slds-m-left_x-small"
           onclick={cancelQuestionEdit}
+        >
+        </lightning-button>
+
+        <lightning-button
+          variant="brand"
+          label={label.save_changes}
+          class="slds-m-left_x-small"
+          onclick={updateQuestion}
         >
         </lightning-button>
       </template>

--- a/force-app/main/default/lwc/questionForm/questionForm.js
+++ b/force-app/main/default/lwc/questionForm/questionForm.js
@@ -12,7 +12,8 @@ import {
   filterOptionsByValue,
   updateOptionsValue,
   deleteFromOptions,
-  clearInput
+  clearInput,
+  setInputValidity
 } from "./questionFormHelper.js";
 
 export default class QuestionForm extends LightningElement {
@@ -26,6 +27,8 @@ export default class QuestionForm extends LightningElement {
 
   REQUIRED_FIELD_API_NAME = "Required__c";
   REUSABLE_FIELD_API_NAME = "IsReusable__c";
+
+  EMPTRY_STRING = "";
 
   @track question;
 
@@ -132,7 +135,7 @@ export default class QuestionForm extends LightningElement {
       Value__c: input.value
     });
 
-    input.value = "";
+    clearInput(input);
   }
 
   editOption(event) {
@@ -168,7 +171,10 @@ export default class QuestionForm extends LightningElement {
   }
 
   isOptionCorrect(input) {
-    if (!input.validity.valid) return false;
+    if (input.value === this.EMPTRY_STRING) {
+      setInputValidity(input, label.complete_this_field);
+      return false;
+    }
 
     const filteredOptions = filterOptionsByValue(this.question.Question_Options__r, input.value);
 
@@ -225,7 +231,8 @@ export default class QuestionForm extends LightningElement {
   isQuestionCorrect() {
     const input = this.template.querySelector(".input");
 
-    if (!input.validity.valid) {
+    if (input.value === this.EMPTRY_STRING) {
+      setInputValidity(input, label.complete_this_field);
       return false;
     } else if (
       this.isOptionsEnabled &&
@@ -245,7 +252,6 @@ export default class QuestionForm extends LightningElement {
   resetForm() {
     const input = this.template.querySelector(".input");
     clearInput(input);
-    input.value = "";
     this.selectedType = this.displayedTypes
       ? this.displayedTypes[0].value
       : "Text";

--- a/force-app/main/default/lwc/questionForm/questionFormHelper.js
+++ b/force-app/main/default/lwc/questionForm/questionFormHelper.js
@@ -43,8 +43,16 @@ const deleteFromOptions = (options, selectedValue) => {
 }
 
 const clearInput = (input) => {
-  input.value = ".";
-  input.focus();
+  // input.value = ".";
+  // input.focus();
+  input.setCustomValidity("");
+  input.reportValidity();
+  input.value = "";
+  input.blur();
+}
+
+const setInputValidity = (input, message) => {
+  input.setCustomValidity(message);
   input.reportValidity();
 }
 
@@ -54,5 +62,6 @@ export {
   filterOptionsByValue,
   updateOptionsValue,
   deleteFromOptions,
-  clearInput
+  clearInput,
+  setInputValidity
 }

--- a/force-app/main/default/lwc/questionForm/questionFormHelper.js
+++ b/force-app/main/default/lwc/questionForm/questionFormHelper.js
@@ -43,8 +43,6 @@ const deleteFromOptions = (options, selectedValue) => {
 }
 
 const clearInput = (input) => {
-  // input.value = ".";
-  // input.focus();
   input.setCustomValidity("");
   input.reportValidity();
   input.value = "";

--- a/force-app/main/default/lwc/validationForm/validationForm.html
+++ b/force-app/main/default/lwc/validationForm/validationForm.html
@@ -17,19 +17,6 @@
       <div class="slds-size_1-of-5">
         <div class="slds-m-around_x-small">
           <lightning-combobox
-            label={label.dependent_question}
-            value={secondPosition}
-            options={questionOptions}
-            onchange={selectSecondQuestion}
-            class="secondCombobox"
-          >
-          </lightning-combobox>
-        </div>
-      </div>
-
-      <div class="slds-size_1-of-5">
-        <div class="slds-m-around_x-small">
-          <lightning-combobox
             label={label.operator}
             value={selectedOperator}
             placeholder={label.select_operator}
@@ -60,6 +47,19 @@
             class="input"
             required
           ></lightning-input>
+        </div>
+      </div>
+
+      <div class="slds-size_1-of-5">
+        <div class="slds-m-around_x-small">
+          <lightning-combobox
+            label={label.dependent_question}
+            value={secondPosition}
+            options={questionOptions}
+            onchange={selectSecondQuestion}
+            class="secondCombobox"
+          >
+          </lightning-combobox>
         </div>
       </div>
 

--- a/force-app/main/default/lwc/validationForm/validationForm.js
+++ b/force-app/main/default/lwc/validationForm/validationForm.js
@@ -176,8 +176,6 @@ export default class ValidationForm extends LightningElement {
       detail: validation
     });
     this.dispatchEvent(addEvent);
-
-    this.resetForm();
   }
 
   sendErrorNotification() {
@@ -185,6 +183,7 @@ export default class ValidationForm extends LightningElement {
     this.dispatchEvent(errorEvent);
   }
 
+  @api
   resetForm() {
     this.firstPosition = this.questions[0].Position__c;
     this.secondPosition = this.questions[1].Position__c;

--- a/force-app/main/default/lwc/validationScreen/labels.js
+++ b/force-app/main/default/lwc/validationScreen/labels.js
@@ -4,6 +4,8 @@ import no_validations from "@salesforce/label/c.no_validations";
 import previous_button_message from "@salesforce/label/c.previous_button_message";
 import previous from "@salesforce/label/c.previous";
 import next from "@salesforce/label/c.next";
+import error_title from "@salesforce/label/c.error";
+import questions_connected from "@salesforce/label/c.questions_connected";
 
 const label = {
   no_questions_to_validation,
@@ -11,7 +13,9 @@ const label = {
   no_validations,
   previous_button_message,
   previous,
-  next
+  next,
+  error_title,
+  questions_connected
 };
 
 export {

--- a/force-app/main/default/lwc/validationScreen/validationScreen.js
+++ b/force-app/main/default/lwc/validationScreen/validationScreen.js
@@ -2,8 +2,14 @@ import { LightningElement, api, track } from "lwc";
 
 import { label } from "./labels.js";
 import { FlowNavigationBackEvent, FlowNavigationNextEvent } from 'lightning/flowSupport';
+import { isValidNewValidation } from "./validationScreenHelper";
+import { ShowToastEvent } from "lightning/platformShowToastEvent";
 
 export default class ValidationScreen extends LightningElement {
+
+
+  ERROR_VARIANT = "error";
+
   @track displayedValidations = [];
 
   get validations() {
@@ -25,7 +31,7 @@ export default class ValidationScreen extends LightningElement {
 
   connectedCallback() {
     if (this.questions) {
-      this.isHaveQuestions = this.questions.length > 2;
+      this.isHaveQuestions = this.questions.length >= 2;
     } else {
       this.isHaveQuestions = false;
     }
@@ -35,6 +41,16 @@ export default class ValidationScreen extends LightningElement {
 
   addValidation(event) {
     const validation = event.detail;
+
+    if(!isValidNewValidation(this.displayedValidations, validation)) {
+      this.showToastMessage(label.error_title, label.questions_connected, this.ERROR_VARIANT);
+      return;
+    }
+
+    this.template
+          .querySelectorAll("c-validation-form")[0]
+          .resetForm();
+
     this.displayedValidations.push(validation);
     this.isHaveValidations = this.displayedValidations.length > 0;
   }
@@ -58,5 +74,14 @@ export default class ValidationScreen extends LightningElement {
   clickNextButton() {
     const nextNavigationEvent = new FlowNavigationNextEvent();
     this.dispatchEvent(nextNavigationEvent);
+  }
+
+  showToastMessage(title, message, variant) {
+    const event = new ShowToastEvent({
+      title,
+      message,
+      variant
+    });
+    this.dispatchEvent(event);
   }
 }

--- a/force-app/main/default/lwc/validationScreen/validationScreenHelper.js
+++ b/force-app/main/default/lwc/validationScreen/validationScreenHelper.js
@@ -1,0 +1,14 @@
+const isValidNewValidation = (validations, newValidation) => {
+  const fileteredValidations = validations.filter((validation) => {
+      return (validation.Related_Question__c.Position__c === newValidation.Related_Question__c.Position__c  &&
+            validation.Dependent_Question__c.Position__c === newValidation.Dependent_Question__c.Position__c) 
+            || 
+            (validation.Related_Question__c.Position__c === newValidation.Dependent_Question__c.Position__c  &&
+            validation.Dependent_Question__c.Position__c === newValidation.Related_Question__c.Position__c) ;
+  })
+  return fileteredValidations.length === 0;
+}
+
+export {
+  isValidNewValidation
+}


### PR DESCRIPTION
В описании этого пр опираюсь на составленный документ с багами. 

Пофикшено:
1. Пофикшен баг номер 2. У input-ов убрано required, и стоит полностью кастомная валидация, которая проверяет незаполненность поля на стороне JS. 
2. Пофикшен баг номер 9. Решение аналогично первому.
3. Пофикшен баг номер 8. Добавлена проверка, которая проверяет, существует ли валидация, основанная на таких же вопросах. Т.е., т.е. реализовать взаимоисключающую валидацию невозможно, ровно как и две валидации на те же самые вопросы. 
4. Пофикшен баг номер 12. Решение крылось в Flow. Правда, в связи с тем что безболезненно удалить выходящий аргумент из компненты скрина нельзя, пришлось пересоздавать скрин полностью, в виду чего залетело две новых версии.

Мелкие фиксы из секции ВАЖНОЕ(но поменьше)
1.Баг UI номер 9. Кнопка отмена в форме вопросов теперь слева
2.Баг UI номер 12. Порядок элементов в форме валидации теперь следующий:
Вопрос-поставщик зависимости => оператор => значение => зависимый вопрос